### PR TITLE
Fixed JS bug in stack.html and tags.html that broke the rendering of the page

### DIFF
--- a/stack.html
+++ b/stack.html
@@ -123,7 +123,7 @@ function listCompanies()
 	    $.getJSON('data/tags.json', function(data) {
 
 	    	 tagcount = data['tags'].length;
-	    	 companycount = companies['company'].length;
+	    	 companycount = companies.length;
 	    	 document.getElementById("summary-count").innerHTML = companycount + ' companies represented so far... ';	    	 	
 	    	 	
   			var select = document.getElementById("tag-select");    	 	
@@ -147,7 +147,7 @@ function listCompanies()
 		            var html = Mustache.to_html(template, val);
 		            $('#companyListing').append(html);  				
 					
-			         $.each(companies['company'], function(key2, val2) {
+			         $.each(companies, function(key2, val2) {
 				         	
 			            company = val2['name'];             
 			            tags = val2['tags'];	

--- a/tags.html
+++ b/tags.html
@@ -15,7 +15,7 @@ title: The API Stack
 		    $.getJSON('data/tags.json', function(data) {
 		    	
 		    	 tagcount = data['tags'].length;
-		    	 companycount = companies['company'].length;
+		    	 companycount = companies.length;
 		    	 document.getElementById("summary-count").innerHTML = companycount + ' companies in ' + tagcount + ' arenas';
 		    
 		         $.each(data['tags'], function(key, val) {         	   


### PR DESCRIPTION
Companies.json data model changed and now returns directly the array of objects - no need for accessing it through companies['company'] key any more.